### PR TITLE
Morph Name Attribute and rename some classes in model.residence package

### DIFF
--- a/src/main/java/seedu/address/model/residence/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/residence/NameContainsKeywordsPredicate.java
@@ -6,7 +6,7 @@ import java.util.function.Predicate;
 import seedu.address.commons.util.StringUtil;
 
 /**
- * Tests that a {@code Residence}'s {@code Name} matches any of the keywords given.
+ * Tests that a {@code Residence}'s {@code ResidenceName} matches any of the keywords given.
  */
 public class NameContainsKeywordsPredicate implements Predicate<Residence> {
     private final List<String> keywords;

--- a/src/main/java/seedu/address/model/residence/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/residence/NameContainsKeywordsPredicate.java
@@ -18,7 +18,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Residence> {
     @Override
     public boolean test(Residence residence) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(residence.getName().fullName, keyword));
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(residence.getResidenceName().fullName, keyword));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/residence/Residence.java
+++ b/src/main/java/seedu/address/model/residence/Residence.java
@@ -11,16 +11,16 @@ import seedu.address.model.tag.CleanStatusTag;
 import seedu.address.model.tag.Tag;
 
 /**
- * Represents a Residence in the address book.
+ * Represents a Residence in the residenceAddress book.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
 public class Residence {
 
     // Identity fields
-    private final Name name;
+    private final ResidenceName residenceName;
 
     // Data fields
-    private final Address address;
+    private final ResidenceAddress residenceAddress;
     private final BookingDetails bookingDetails;
     private final Set<CleanStatusTag> cleanStatusTag = new HashSet<>();
     private final Set<Tag> tags = new HashSet<>();
@@ -28,22 +28,22 @@ public class Residence {
     /**
      * Every field must be present and not null.
      */
-    public Residence(Name name, Address address, BookingDetails bookingDetails,
+    public Residence(ResidenceName residenceName, ResidenceAddress residenceAddress, BookingDetails bookingDetails,
                      Set<CleanStatusTag> cleanStatusTag, Set<Tag> tags) {
         this.bookingDetails = bookingDetails;
-        requireAllNonNull(name, address, cleanStatusTag, tags);
-        this.name = name;
-        this.address = address;
+        requireAllNonNull(residenceName, residenceAddress, cleanStatusTag, tags);
+        this.residenceName = residenceName;
+        this.residenceAddress = residenceAddress;
         this.cleanStatusTag.addAll(cleanStatusTag);
         this.tags.addAll(tags);
     }
 
-    public Name getName() {
-        return name;
+    public ResidenceName getName() {
+        return residenceName;
     }
 
-    public Address getAddress() {
-        return address;
+    public ResidenceAddress getAddress() {
+        return residenceAddress;
     }
 
     public BookingDetails getBookingDetails() {
@@ -68,7 +68,7 @@ public class Residence {
     }
 
     /**
-     * Returns true if both residences have the same name.
+     * Returns true if both residences have the same residenceName.
      * This defines a weaker notion of equality between two residences.
      */
     public boolean isSameResidence(Residence otherResidence) {
@@ -105,14 +105,14 @@ public class Residence {
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, address, bookingDetails, cleanStatusTag, tags);
+        return Objects.hash(residenceName, residenceAddress, bookingDetails, cleanStatusTag, tags);
     }
 
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();
         builder.append(getName())
-                .append("; Address: ")
+                .append("; ResidenceAddress: ")
                 .append(getAddress())
                 .append("; Booking Details: ")
                 .append(getBookingDetails());

--- a/src/main/java/seedu/address/model/residence/Residence.java
+++ b/src/main/java/seedu/address/model/residence/Residence.java
@@ -11,7 +11,7 @@ import seedu.address.model.tag.CleanStatusTag;
 import seedu.address.model.tag.Tag;
 
 /**
- * Represents a Residence in the residenceAddress book.
+ * Represents a Residence in ResidenceTracker.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
 public class Residence {
@@ -38,11 +38,11 @@ public class Residence {
         this.tags.addAll(tags);
     }
 
-    public ResidenceName getName() {
+    public ResidenceName getResidenceName() {
         return residenceName;
     }
 
-    public ResidenceAddress getAddress() {
+    public ResidenceAddress getResidenceAddress() {
         return residenceAddress;
     }
 
@@ -77,7 +77,7 @@ public class Residence {
         }
 
         return otherResidence != null
-                && otherResidence.getName().equals(getName());
+                && otherResidence.getResidenceName().equals(getResidenceName());
     }
 
     /**
@@ -95,8 +95,8 @@ public class Residence {
         }
 
         Residence otherResidence = (Residence) other;
-        return otherResidence.getName().equals(getName())
-                && otherResidence.getAddress().equals(getAddress())
+        return otherResidence.getResidenceName().equals(getResidenceName())
+                && otherResidence.getResidenceAddress().equals(getResidenceAddress())
                 && otherResidence.getBookingDetails().equals(getBookingDetails())
                 && otherResidence.getCleanStatusTag().equals(getCleanStatusTag())
                 && otherResidence.getTags().equals(getTags());
@@ -111,9 +111,9 @@ public class Residence {
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();
-        builder.append(getName())
-                .append("; ResidenceAddress: ")
-                .append(getAddress())
+        builder.append(getResidenceName())
+                .append("; Residence Address: ")
+                .append(getResidenceAddress())
                 .append("; Booking Details: ")
                 .append(getBookingDetails());
 

--- a/src/main/java/seedu/address/model/residence/ResidenceAddress.java
+++ b/src/main/java/seedu/address/model/residence/ResidenceAddress.java
@@ -4,15 +4,15 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Residence's address in the address book.
+ * Represents a Residence's address in ResidenceTracker.
  * Guarantees: immutable; is valid as declared in {@link #isValidAddress(String)}
  */
-public class Address {
+public class ResidenceAddress {
 
     public static final String MESSAGE_CONSTRAINTS = "Addresses can take any values, and it should not be blank";
 
     /*
-     * The first character of the address must not be a whitespace,
+     * The first character of the Residence's address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
     public static final String VALIDATION_REGEX = "[^\\s].*";
@@ -20,11 +20,11 @@ public class Address {
     public final String value;
 
     /**
-     * Constructs an {@code Address}.
+     * Constructs an {@code ResidenceAddress}.
      *
      * @param address A valid address.
      */
-    public Address(String address) {
+    public ResidenceAddress(String address) {
         requireNonNull(address);
         checkArgument(isValidAddress(address), MESSAGE_CONSTRAINTS);
         value = address;
@@ -45,8 +45,8 @@ public class Address {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof Address // instanceof handles nulls
-                && value.equals(((Address) other).value)); // state check
+                || (other instanceof ResidenceAddress // instanceof handles nulls
+                && value.equals(((ResidenceAddress) other).value)); // state check
     }
 
     @Override

--- a/src/main/java/seedu/address/model/residence/ResidenceAddress.java
+++ b/src/main/java/seedu/address/model/residence/ResidenceAddress.java
@@ -5,7 +5,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
  * Represents a Residence's address in ResidenceTracker.
- * Guarantees: immutable; is valid as declared in {@link #isValidAddress(String)}
+ * Guarantees: immutable; is valid as declared in {@link #isValidResidenceAddress(String)}
  */
 public class ResidenceAddress {
 
@@ -26,14 +26,14 @@ public class ResidenceAddress {
      */
     public ResidenceAddress(String address) {
         requireNonNull(address);
-        checkArgument(isValidAddress(address), MESSAGE_CONSTRAINTS);
+        checkArgument(isValidResidenceAddress(address), MESSAGE_CONSTRAINTS);
         value = address;
     }
 
     /**
      * Returns true if a given string is a valid address.
      */
-    public static boolean isValidAddress(String test) {
+    public static boolean isValidResidenceAddress(String test) {
         return test.matches(VALIDATION_REGEX);
     }
 

--- a/src/main/java/seedu/address/model/residence/ResidenceName.java
+++ b/src/main/java/seedu/address/model/residence/ResidenceName.java
@@ -4,16 +4,16 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Residence's name in the address book.
+ * Represents a Residence's name in the ResidenceTracker.
  * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
  */
-public class Name {
+public class ResidenceName {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Names should only contain alphanumeric characters and spaces, and it should not be blank";
 
     /*
-     * The first character of the address must not be a whitespace,
+     * The first character of the Residence's name must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
     public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
@@ -21,11 +21,11 @@ public class Name {
     public final String fullName;
 
     /**
-     * Constructs a {@code Name}.
+     * Constructs a {@code ResidenceName}.
      *
      * @param name A valid name.
      */
-    public Name(String name) {
+    public ResidenceName(String name) {
         requireNonNull(name);
         checkArgument(isValidName(name), MESSAGE_CONSTRAINTS);
         fullName = name;
@@ -47,8 +47,8 @@ public class Name {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof Name // instanceof handles nulls
-                && fullName.equals(((Name) other).fullName)); // state check
+                || (other instanceof ResidenceName // instanceof handles nulls
+                && fullName.equals(((ResidenceName) other).fullName)); // state check
     }
 
     @Override

--- a/src/main/java/seedu/address/model/residence/ResidenceName.java
+++ b/src/main/java/seedu/address/model/residence/ResidenceName.java
@@ -5,7 +5,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
  * Represents a Residence's name in the ResidenceTracker.
- * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
+ * Guarantees: immutable; is valid as declared in {@link #isValidResidenceName(String)}
  */
 public class ResidenceName {
 
@@ -27,14 +27,14 @@ public class ResidenceName {
      */
     public ResidenceName(String name) {
         requireNonNull(name);
-        checkArgument(isValidName(name), MESSAGE_CONSTRAINTS);
+        checkArgument(isValidResidenceName(name), MESSAGE_CONSTRAINTS);
         fullName = name;
     }
 
     /**
      * Returns true if a given string is a valid name.
      */
-    public static boolean isValidName(String test) {
+    public static boolean isValidResidenceName(String test) {
         return test.matches(VALIDATION_REGEX);
     }
 


### PR DESCRIPTION
Fixes #37.

Rename Name and Address class in model.residence package to ResidenceName and ResidenceAddress respectively to avoid confusion with Name and Address class in model.person package which the project might be using in later stages.