### PR TITLE
Fix bug that changes clean status when typing edit INDEX

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -18,7 +18,7 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a residence to the residence tracker. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a residence to the residence tracker.\n"
             + "Parameters: "
             + PREFIX_RESIDENCE_NAME + "NAME "
             + PREFIX_RESIDENCE_ADDRESS + "ADDRESS "

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -28,8 +28,7 @@ public class AddCommand extends Command {
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_RESIDENCE_NAME + "Seaside Villa "
             + PREFIX_RESIDENCE_ADDRESS + "311, Pasir Ris Ave 2, #02-25 "
-            + PREFIX_BOOKING_DETAILS + "Family of 3 "
-            + PREFIX_CLEAN_STATUS_TAG + "y"
+            + PREFIX_CLEAN_STATUS_TAG + "n"
             + PREFIX_TAG + "friends ";
 
     public static final String MESSAGE_SUCCESS = "New residence added: %1$s";

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -33,9 +33,9 @@ public class EditCommand extends Command {
             + "by the index number used in the displayed residence list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_CLEAN_STATUS_TAG + " y/n] "
-            + "Example: " + COMMAND_WORD
-            + PREFIX_CLEAN_STATUS_TAG + " y 1 ";
+            + "[" + PREFIX_CLEAN_STATUS_TAG + "n]\n"
+            + "Example: " + COMMAND_WORD + "1 "
+            + PREFIX_CLEAN_STATUS_TAG + "y";
 
     public static final String MESSAGE_EDIT_RESIDENCE_SUCCESS = "Edited Residence: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
@@ -123,10 +123,8 @@ public class EditCommand extends Command {
     public static class EditResidenceDescriptor {
         private ResidenceName residenceName;
         private ResidenceAddress residenceAddress;
-        // because CleanStatusTag has default value
-        private BookingList bookingList = new BookingList();
-        // because CleanStatusTag has default value
-        private CleanStatusTag cleanStatusTag = new CleanStatusTag();
+        private BookingList bookingList;
+        private CleanStatusTag cleanStatusTag;
         private Set<Tag> tags;
 
         public EditResidenceDescriptor() {

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -12,10 +12,10 @@ public class HelpCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
             + "Example: " + COMMAND_WORD;
 
-    public static final String SHOWING_HELP_MESSAGE = "Opened help window.";
+    public static final String HELP_MESSAGE_DISPLAY = "Opened help window.";
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        return new CommandResult(HELP_MESSAGE_DISPLAY, true, false);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -45,7 +45,7 @@ public class AddCommandParser implements Parser<AddCommand> {
 
         BookingList bookingList;
         if (argMultimap.getAllValues(PREFIX_BOOKING_DETAILS).size() > 0) {
-            bookingList = ParserUtil.parseBooking(
+            bookingList = ParserUtil.parseBookingList(
                     argMultimap.getValue(PREFIX_BOOKING_DETAILS).get());
         } else {
             bookingList = new BookingList();

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,7 +11,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_BOOKING_DETAILS = new Prefix("b/");
     public static final Prefix PREFIX_RESIDENCE_ADDRESS = new Prefix("a/");
-    public static final Prefix PREFIX_CLEAN_STATUS_TAG = new Prefix("clean/");
+    public static final Prefix PREFIX_CLEAN_STATUS_TAG = new Prefix("c/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
 
 

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -56,7 +56,7 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         if (argMultimap.getValue(PREFIX_BOOKING_DETAILS).isPresent()) {
             editResidenceDescriptor.setBookingDetails(
-                    ParserUtil.parseBooking(argMultimap.getValue(PREFIX_BOOKING_DETAILS).get()));
+                    ParserUtil.parseBookingList(argMultimap.getValue(PREFIX_BOOKING_DETAILS).get()));
         }
 
         if (argMultimap.getValue(PREFIX_CLEAN_STATUS_TAG).isPresent()) {

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -107,7 +107,7 @@ public class ParserUtil {
      *
      * @throws ParseException if the given {@code booking} is invalid.
      */
-    public static BookingList parseBooking(String bookingDetails) throws ParseException {
+    public static BookingList parseBookingList(String bookingDetails) throws ParseException {
         requireNonNull(bookingDetails);
         String trimmedBooking = bookingDetails.trim();
         if (!BookingList.isValidBooking(trimmedBooking)) {

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -14,7 +14,7 @@ import seedu.address.model.residence.Residence;
 public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Residence> PREDICATE_SHOW_ALL_RESIDENCES = unused -> true;
-    Predicate<Booking> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
+    Predicate<Booking> PREDICATE_SHOW_ALL_BOOKINGS = unused -> true;
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -113,7 +113,7 @@ public class ModelManager implements Model {
         residenceTracker.setResidence(target, editedResidence);
     }
 
-    //=========== Filtered Residence and Person List Accessors ===============================================
+    //=========== Filtered Residence and Residence List Accessors ===============================================
 
     /**
      * Returns an unmodifiable view of the list of {@code Residence} backed by the internal list of

--- a/src/main/java/seedu/address/model/residence/Residence.java
+++ b/src/main/java/seedu/address/model/residence/Residence.java
@@ -109,8 +109,6 @@ public class Residence {
         builder.append(getResidenceName())
                 .append("; Residence Address: ")
                 .append(getResidenceAddress())
-                .append("; Booking Details: ")
-                .append(getBookingDetails())
                 .append("; Clean Status: ")
                 .append(getCleanStatusTag());
 

--- a/src/main/java/seedu/address/model/tag/CleanStatusTag.java
+++ b/src/main/java/seedu/address/model/tag/CleanStatusTag.java
@@ -10,7 +10,7 @@ public class CleanStatusTag {
     public static final String CLEAN_DESC = "y";
     public static final String UNCLEAN_DESC = "n";
 
-    private static String MESSAGE_CONSTRAINTS = "should use y or n to show clean status";
+    private static String MESSAGE_CONSTRAINTS = "Please use 'c/y', 'c/n', 'c/clean' or 'c/unclean'";
 
     private String cleanStatus;
 
@@ -24,15 +24,15 @@ public class CleanStatusTag {
     /**
      * Constructs a {@code CleanStatusTag}.
      *
-     * @param cleanStatus define the clean status by y or n.
+     * @param cleanStatus A valid clean status.
      */
     public CleanStatusTag(String cleanStatus) {
         requireNonNull(cleanStatus);
         System.out.println("TESTING FOR CLEAN STATUS: " + cleanStatus);
         checkArgument(isValidCleanStatusTag(cleanStatus), MESSAGE_CONSTRAINTS);
-        if (cleanStatus.equalsIgnoreCase("y")) {
+        if (cleanStatus.equalsIgnoreCase("y") || cleanStatus.equalsIgnoreCase("clean")) {
             this.cleanStatus = CLEAN;
-        } else if (cleanStatus.equalsIgnoreCase("n")) {
+        } else if (cleanStatus.equalsIgnoreCase("n") || cleanStatus.equalsIgnoreCase("unclean")) {
             this.cleanStatus = UNCLEAN;
         }
     }
@@ -41,7 +41,8 @@ public class CleanStatusTag {
      * Returns true if a given string is a valid tag name.
      */
     public static boolean isValidCleanStatusTag(String test) {
-        return test.equalsIgnoreCase("y") || test.equalsIgnoreCase("n");
+        return test.equalsIgnoreCase("y") || test.equalsIgnoreCase("n")
+                || test.equalsIgnoreCase("clean") || test.equalsIgnoreCase("unclean");
     }
 
     /**
@@ -49,16 +50,6 @@ public class CleanStatusTag {
      */
     public String getValue() {
         return cleanStatus;
-    }
-
-    /**
-     * Returns expected user input description of this {@code CleanStatusTag}.
-     */
-    public String getDesc() {
-        if (this.cleanStatus.equals(CLEAN)) {
-            return CLEAN_DESC;
-        }
-        return UNCLEAN_DESC;
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -32,15 +32,15 @@ public class HelpWindow extends UiPart<Stage> {
                                              + "\nEnter \"delete INDEX\""
                                              + "\nExample: delete 3\n\n";
 
-    public static final String EDIT_PROMPT = "edit - Edits the booking/cleaning status of an existing residence."
-                                           + "\nEnter \"edit INDEX clean/[y or n] \""
-                                           + "\nExample: edit clean/n 2\n\n";
+    public static final String EDIT_PROMPT = "edit - Edits fields of an existing residence (other than bookings)."
+                                           + "\nEnter \"edit INDEX c/n \""
+                                           + "\nExample: edit 2 c/n\n\n";
 
     public static final String FIND_PROMPT = "find - Finds residences whose name contains the given keyword."
-                                           + "\nEnter \"find KEYWORD\""
-                                           + "\nExample: find Heights\n\n";
+                                           + "\nEnter \"find KEYWORDS\""
+                                           + "\nExample: find Heights Condo\n\n";
 
-    public static final String LIST_PROMPT = "list - Shows a list of all residences in ResidenceTracker app."
+    public static final String LIST_PROMPT = "list - Shows a list of all residences in ResidenceTracker."
                                            + "\n Enter \"list\"\n\n";
 
     public static final String EXIT_PROMPT = "exit - Exits the program."

--- a/src/test/java/seedu/address/testutil/ResidenceUtil.java
+++ b/src/test/java/seedu/address/testutil/ResidenceUtil.java
@@ -57,7 +57,7 @@ public class ResidenceUtil {
         descriptor.getBookingDetails().ifPresent(booking -> sb.append(PREFIX_BOOKING_DETAILS)
                 .append(booking.getValue()).append(" "));
         descriptor.getCleanStatusTag().ifPresent(cleanStatusTag -> sb.append(PREFIX_CLEAN_STATUS_TAG)
-                .append(cleanStatusTag.getDesc()).append(" "));
+                .append(cleanStatusTag.getValue()).append(" "));
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {


### PR DESCRIPTION
Fixes #114 

Additional changes:
1. Some corrections to error messages
2. Removed bookingList from the residence toString method for simpler representation on the error message box
3. Changed 'clean/' to 'c/' and allow 'clean' and 'unclean' as valid clean status inputs as was discussed